### PR TITLE
feat(consumer): add channel, method, and properties to the specified …

### DIFF
--- a/pyrmq/consumer.py
+++ b/pyrmq/consumer.py
@@ -237,7 +237,9 @@ class Consumer(object):
         try:
             logger.debug("Received message from queue")
 
-            self.message_received_callback(data)
+            self.message_received_callback(
+                data, channel=channel, method=method, properties=properties
+            )
 
         except Exception as error:
             if self.is_dlk_retry_enabled:

--- a/pyrmq/tests/test_publisher.py
+++ b/pyrmq/tests/test_publisher.py
@@ -163,7 +163,7 @@ def should_publish_to_the_routed_queue_as_specified_in_headers():
 
     first_response = {"count": 0}
 
-    def first_callback(data: Dict):
+    def first_callback(data: Dict, **kwargs):
         first_response["count"] += 1
 
     first_consumer = Consumer(
@@ -180,7 +180,7 @@ def should_publish_to_the_routed_queue_as_specified_in_headers():
 
     second_response = {"count": 0}
 
-    def second_callback(data: Dict):
+    def second_callback(data: Dict, **kwargs):
         second_response["count"] += 1
 
     second_consumer = Consumer(

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,9 @@ passenv =
     RABBITMQ_PORT
     REPORT
 deps =
-    pytest
-    pytest-cov
-    pre-commit
+    pytest==6.2.1
+    pytest-cov==2.10.1
+    pre-commit==2.9.3
 commands =
     pre-commit run --all-files
     pytest -v --durations=0 --cov=pyrmq --cov-report=term --cov-fail-under 100 --cov-report={env:REPORT:html}


### PR DESCRIPTION
…callback as kwargs

BREAKING CHANGE: specified Consumer callback methods should accept
`channel`, `method`, and `properties` as additional keyword arguments