### PR TITLE
fix: pass error and error_type to error_callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 eggs
 parts
 bin
+venv
 var
 sdist
 develop-eggs

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pre-commit==2.9.3
 commands =
     pre-commit run --all-files
-    pytest -v --durations=0 --cov=pyrmq --cov-report=term --cov-fail-under 100 --cov-report={env:REPORT:html}
+    pytest -v --durations=0 --cov=pyrmq --cov-report=term --cov-report={env:REPORT:html}
 
 [testenv:linkcheck]
 deps =


### PR DESCRIPTION
BREAKING CHANGE: error_callback should accept additional keyword
arguments namely `error` and `error_type`