### PR TITLE
support for consumer: manual ack, invalid msg handle, long run callback in new thread

### DIFF
--- a/pyrmq/consumer.py
+++ b/pyrmq/consumer.py
@@ -274,10 +274,17 @@ class Consumer(object):
         :param data: Data received in bytes.
         """
 
-        if isinstance(data, bytes):
-            data = data.decode("ascii")
+        try:
+            if isinstance(data, bytes):
+                data = data.decode("ascii")
 
-        data = json.loads(data)
+            data = json.loads(data)
+
+        except Exception as error:
+            # ignore invalid message
+            self.__send_consume_error_message(error)
+            channel.basic_ack(delivery_tag=method.delivery_tag)
+            return
 
         auto_ack = None
 

--- a/pyrmq/consumer.py
+++ b/pyrmq/consumer.py
@@ -68,7 +68,7 @@ class Consumer(object):
         :keyword exchange_args: Your exchange arguments. Default: ``None``
         :keyword queue_args: Your queue arguments. Default: ``None``
         :keyword bound_exchange: The exchange this consumer needs to bind to. This is an object that has two keys, ``name`` and ``type``. Default: ``None``
-        :keyword auto_ack: Flag whether to ack or nack the consumed message regardless of its outcome. Default: ``True``
+        :keyword auto_ack: Flag whether to ack or nack the consumed message regardless of its outcome. if False and callback returns None, none ack/nack is performed. Default: ``True``
         :keyword prefetch_count: How many messages should the consumer retrieve at a time for consumption. Default: ``1``
         """
 
@@ -294,12 +294,14 @@ class Consumer(object):
 
             else:
                 self.__send_consume_error_message(error)
+            auto_ack = True # force ack when exception.
 
         if auto_ack or (auto_ack is None and self.auto_ack):
             channel.basic_ack(delivery_tag=method.delivery_tag)
 
-        else:
+        elif not self.auto_ack and auto_ack is not None:
             channel.basic_nack(delivery_tag=method.delivery_tag)
+        # else: manual ack if (auto_ack is None and not self.auto_ack)
 
     def connect(self, retry_count=1) -> None:
         """

--- a/pyrmq/tests/test_consumer.py
+++ b/pyrmq/tests/test_consumer.py
@@ -9,6 +9,7 @@
 import logging
 from random import randint
 from time import sleep
+import time
 from unittest.mock import patch
 
 import pytest
@@ -401,3 +402,31 @@ def should_consume_from_the_routed_queue_as_specified_in_headers() -> None:
     second_consumer.start()
     assert_consumed_message(second_response, {"count": 1})
     second_consumer.close()
+
+
+def should_long_run_callback_in_new_thread(
+    publisher_session: Publisher,
+) -> None:
+    body = {"test": "test"}
+
+    publisher_session.publish(
+        body, message_properties={"headers": {"x-origin": "sample"}}
+    )
+
+    response = {"count": 0}
+
+    running_secs = 20
+    def long_run_callback(data: dict, **kwargs):
+        time.sleep(running_secs)
+        response["count"] = response["count"] + 1
+
+    consumer = Consumer(
+        exchange_name=publisher_session.exchange_name,
+        queue_name=publisher_session.queue_name,
+        routing_key=publisher_session.routing_key,
+        callback=long_run_callback,
+        long_run_callback=True,
+    )
+    consumer.start()
+    assert_consumed_message(response, {"count": 1}, tries=-100, retry_after=1)
+    consumer.close()

--- a/pyrmq/tests/test_consumer.py
+++ b/pyrmq/tests/test_consumer.py
@@ -403,6 +403,38 @@ def should_consume_from_the_routed_queue_as_specified_in_headers() -> None:
     assert_consumed_message(second_response, {"count": 1})
     second_consumer.close()
 
+def should_manual_ack(
+    publisher_session: Publisher,
+) -> None:
+    body = {"test": "test"}
+
+    publisher_session.publish(
+        body, message_properties={"headers": {"x-origin": "sample"}}
+    )
+
+    response, ack_tool = {"count": 0}, {"delivery_tag": None, "channel": None}
+
+    def manual_ack_callback(data: dict, channel=None, method=None, properties=None):
+        response["count"] = response["count"] + 1
+        ack_tool['delivery_tag'], ack_tool['channel'] = method.delivery_tag, channel
+
+    consumer = Consumer(
+        exchange_name=publisher_session.exchange_name,
+        queue_name=publisher_session.queue_name,
+        routing_key=publisher_session.routing_key,
+        callback=manual_ack_callback,
+        auto_ack=False
+    )
+    consumer.start()
+    assert_consumed_message(response, {"count": 1})
+    ack_tool['channel'].basic_nack(delivery_tag=ack_tool['delivery_tag'])
+
+    # wait for redelivery
+    assert_consumed_message(response, {"count": 2}, tries=-40)
+    ack_tool['channel'].basic_ack(delivery_tag=ack_tool['delivery_tag'])
+
+    consumer.close()
+
 
 def should_long_run_callback_in_new_thread(
     publisher_session: Publisher,


### PR DESCRIPTION
For consumer:
* manual ack: if self.auto_ack == False and callback returns None
* invalid msg handle: error callback if msg body is not json.
* long run callback in new thread: start new thread for callback, to avoid ConnectionResetError(104, 'Connection [reset] by peer')