### PR TITLE
chore: update PyCQA (flake8, isort) repo link

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,13 @@ repos:
         types:
           - python
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.1
+  - repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
         files: 'pyrmq/.*'


### PR DESCRIPTION
- PyCQA now in GitHub instead of GitLab
- update flake8 to 5.0.4
- update isort to 5.12.0