### PR TITLE
chore: add python 3.11 support, remove 3.6 and 3.7

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     services:
       rabbitmq:
         image: rabbitmq:latest
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       rabbitmq:
         image: rabbitmq:latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -40,11 +40,11 @@ jobs:
 
       - name: Check links in Documentation
         run: tox -e linkcheck
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.11'
 
       - name: Run linter
         run: tox -e linting
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.11'
 
       - name: Run test suite
         env:
@@ -62,4 +62,4 @@ jobs:
           flags: tests
           name: codecov-umbrella
           fail_ci_if_error: true
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.11'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
   <h1>PyRMQ</h1>
+  <a href="https://pypi.org/project/PyRMQ/"><img alt="PyPI" src="https://img.shields.io/pypi/v/pyrmq?style=for-the-badge"></a>
   <a href="https://pyrmq.readthedocs.io"><img src='https://readthedocs.org/projects/pyrmq/badge/?version=latest&style=for-the-badge' alt='Documentation Status' /></a>
   <a href="https://codecov.io/gh/first-digital-finance/pyrmq"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/first-digital-finance/pyrmq/master.svg?style=for-the-badge"></a>
   <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.8" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="https://pypi.org/project/PyRMQ/"><img alt="PyPI" src="https://img.shields.io/pypi/v/pyrmq?style=for-the-badge"></a>
   <a href="https://pyrmq.readthedocs.io"><img src='https://readthedocs.org/projects/pyrmq/badge/?version=latest&style=for-the-badge' alt='Documentation Status' /></a>
   <a href="https://codecov.io/gh/first-digital-finance/pyrmq"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/first-digital-finance/pyrmq/master.svg?style=for-the-badge"></a>
-  <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.7" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>
+  <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.8" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>
   <a href="https://mit-license.org" target="_blank"><img src="https://img.shields.io/badge/license-MIT-blue.svg?longCache=true&style=for-the-badge" alt="License"></a> 
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg?longCache=true&style=for-the-badge"></a>
   <a href="https://github.com/PyCQA/isort"><img alt="Imports: isort" src="https://img.shields.io/badge/%20imports-isort-%231674b1?style=for-the-badge&labelColor=ef8336)](https://pycqa.github.io/isort/"></a>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
   <h1>PyRMQ</h1>
-  <a href="https://github.com/first-digital-finance/pyrmq"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/altusgerona/pyrmq/Upload%20PyRMQ%20to%20PyPI?style=for-the-badge"></a>
   <a href="https://pypi.org/project/PyRMQ/"><img alt="PyPI" src="https://img.shields.io/pypi/v/pyrmq?style=for-the-badge"></a>
   <a href="https://pyrmq.readthedocs.io"><img src='https://readthedocs.org/projects/pyrmq/badge/?version=latest&style=for-the-badge' alt='Documentation Status' /></a>
   <a href="https://codecov.io/gh/first-digital-finance/pyrmq"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/first-digital-finance/pyrmq/master.svg?style=for-the-badge"></a>
-  <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.6" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>
+  <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.7" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>
   <a href="https://mit-license.org" target="_blank"><img src="https://img.shields.io/badge/license-MIT-blue.svg?longCache=true&style=for-the-badge" alt="License"></a> 
   <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg?longCache=true&style=for-the-badge"></a>
   <a href="https://github.com/PyCQA/isort"><img alt="Imports: isort" src="https://img.shields.io/badge/%20imports-isort-%231674b1?style=for-the-badge&labelColor=ef8336)](https://pycqa.github.io/isort/"></a>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
   <h1>PyRMQ</h1>
+  <a href="https://github.com/first-digital-finance/pyrmq"><img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/first-digital-finance/pyrmq/testing.yml?branch=master&style=for-the-badge"></a>
   <a href="https://pypi.org/project/PyRMQ/"><img alt="PyPI" src="https://img.shields.io/pypi/v/pyrmq?style=for-the-badge"></a>
   <a href="https://pyrmq.readthedocs.io"><img src='https://readthedocs.org/projects/pyrmq/badge/?version=latest&style=for-the-badge' alt='Documentation Status' /></a>
   <a href="https://codecov.io/gh/first-digital-finance/pyrmq"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/first-digital-finance/pyrmq/master.svg?style=for-the-badge"></a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <!--suppress HtmlDeprecatedAttribute -->
 <div align="center">
   <h1>PyRMQ</h1>
-  <a href="https://pypi.org/project/PyRMQ/"><img alt="PyPI" src="https://img.shields.io/pypi/v/pyrmq?style=for-the-badge"></a>
   <a href="https://pyrmq.readthedocs.io"><img src='https://readthedocs.org/projects/pyrmq/badge/?version=latest&style=for-the-badge' alt='Documentation Status' /></a>
   <a href="https://codecov.io/gh/first-digital-finance/pyrmq"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/first-digital-finance/pyrmq/master.svg?style=for-the-badge"></a>
   <a href="https://pypi.org/project/PyRMQ/"><img alt="Supports Python >= 3.8" src="https://img.shields.io/pypi/pyversions/pyrmq?style=for-the-badge"/></a>

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     test_suite="pyrmq.tests",
     install_requires=["setuptools>=49.6.0", "pika>=1.1.0"],
     keywords=["rabbitmq", "pika", "consumer", "publisher", "queue", "messages"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -52,7 +52,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     test_suite="pyrmq.tests",
     install_requires=["setuptools>=49.6.0", "pika>=1.1.0"],
     keywords=["rabbitmq", "pika", "consumer", "publisher", "queue", "messages"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
@@ -52,9 +52,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands =
 deps =
     PyYAML
     -rdocs/requirements.txt
-whitelist_externals=make
+allowlist_externals=make
 changedir=docs
 commands=make linkcheck
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linkcheck, linting, py37, py38, py39, py310
+envlist = linkcheck, linting, py38, py39, py310, py311
 
 [testenv]
 passenv =
@@ -26,7 +26,7 @@ deps =
 commands=pre-commit run --all-files
 
 [testenv:dev]
-basepython = python3.10
+basepython = python3.11
 usedevelop = True
 deps =
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = linkcheck, linting, py36, py37, py38, py39, py310
+envlist = linkcheck, linting, py37, py38, py39, py310
 
 [testenv]
 passenv =


### PR DESCRIPTION
The current version of isort being used (5.12.0) requires Python >=3.8. Python 3.6 has reached end of life, and 3.7 support will end 2 months from now.